### PR TITLE
Fix installation instructions, use HTTPS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,7 +26,7 @@ Install
 
 First, get the jsawk script:
 
-      curl http://github.com/micha/jsawk/raw/master/jsawk > jsawk
+      curl https://github.com/micha/jsawk/raw/master/jsawk > jsawk
 
 Then make it executable and put it somewhere in your path:
 


### PR DESCRIPTION
This is what happens if I follow the installation instructions in README.md:

```
$ curl http://github.com/micha/jsawk/raw/master/jsawk > jswak
$ cat jsawk
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/0.7.67</center>
</body>
</html>
```

GitHub switched to HTTPS recently, a fix for the README is attached.
