### PR TITLE
Rename "arguments" to "scriptArgs"

### DIFF
--- a/jsawk
+++ b/jsawk
@@ -1105,7 +1105,7 @@ replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
 
   if (!noprint)
     out(RS);
-})(scriptArgs);
+})(typeof arguments === 'undefined' ? scriptArgs : arguments);
 __END__
 
 nlines=0


### PR DESCRIPTION
Corrects https://github.com/micha/jsawk/issues/20 on recent SpiderMonkey. Reference: https://developer.mozilla.org/en-US/docs/SpiderMonkey/Shell_global_objects
