### PR TITLE
Adding in 2 new CLI arguments to provide better support for providing the input to parse

### DIFF
--- a/jsawk
+++ b/jsawk
@@ -1291,16 +1291,33 @@ __END__
 
 nlines=0
 get_lines="yes"
+input_file=
+input_string=
 
-while getopts :hnj:q:f:b:a:v: opt; do
+while getopts :hni:s:j:q:f:b:a:v: opt; do
   case $opt in
     h) get_lines="no" ;;
+    i) input_file="$OPTARG" ;;
     j) js_arg=$OPTARG ;;
+    s) input_string="$OPTARG" ;;
   esac
 done
 
 if [ $get_lines != "no" ]; then
-  echo "$(cat 2>/dev/null)" > $TMP2
+  if [ -n "$input_string" ]; then
+  	# Pass in the input string specified directly
+  	echo "$input_string" > $TMP2
+  elif [ -n "$input_file" ]; then
+  	# Pass in the input file contents specified, first checking the file exists
+  	if ! [ -e "$input_file" ]; then
+  		echo "Error: Input file cannot be found: $input_file"
+  		exit 1
+  	fi
+  	cat "$input_file" > $TMP2
+  else
+  	# Read input from STDIN
+    echo "$(cat 2>/dev/null)" > $TMP2
+  fi
   nlines=$(grep -c '$' $TMP2 2>/dev/null || echo 0)
 fi
 


### PR DESCRIPTION
Adding in support for 2 new command line arguments: 

-i allows an filepath to be passed in as input instead of having to cat it to STDIN. 
-s allows a String literal to be passed as input instead of having to echo it to STDIN.

If neither of those command line arguments are specified it will still read the input from STDIN as before. The reason for this change is it cleans up invocation of jsawk from script files, especially when the input string is already stored in a variable (perhaps returned from a REST Web Service query).

Examples:
# . Parse the input String already retrieved in JSON_TO_PARSE variable:

Before:
VERSION=$(echo "$JSON_TO_PARSE" | jsawk 'return this.version')
Now:
VERSION=$(jsawk -s "$JSON_TO_PARSE" 'return this.version')
# . Parse the input file specified by the JSON_FILE variable:

Before:
VERSION=$(cat "$JSON_FILE | jsawk 'return this.version')
Now:
VERSION=$(jsawk - i "$JSON_FILE" 'return this.version')

When making several different jsawk calls through Bash scripts the new command line options provide tidier (more concise) jsawk invocations
