### PR TITLE
Fixing a bug introduced by my earlier change adding in -s and -i 

### DIFF
--- a/jsawk
+++ b/jsawk
@@ -1181,6 +1181,8 @@ replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
   while (arg = argv.shift()) {
     switch(arg) {
       case "-j":
+      case "-s":
+      case "-i":
         argv.shift();
         break;
       case "-h":


### PR DESCRIPTION
Fixing a bug introduced by my earlier change adding in -s and -i command line arguments. I forgot to also update the Javascript which processes the command line arguments when I updated the bash command line processing. This didn't cause any problems unless you don't specify a main script to run (but just a before or after script). If you don't specify the main script it used the -i or -s value as the main script value.
